### PR TITLE
Correct documentation typos

### DIFF
--- a/src/Annotations.cs
+++ b/src/Annotations.cs
@@ -112,7 +112,7 @@ namespace JetBrains.Annotations
   public sealed class ItemCanBeNullAttribute : Attribute { }
 
   /// <summary>
-  /// Indicates that the marked method builds string by the format pattern and (optional) arguments.
+  /// Indicates that the marked method builds a string by the format pattern and (optional) arguments.
   /// The parameter, which contains the format string, should be given in the constructor. The format string
   /// should be in <see cref="string.Format(IFormatProvider,string,object[])"/>-like form.
   /// </summary>
@@ -131,7 +131,7 @@ namespace JetBrains.Annotations
   public sealed class StringFormatMethodAttribute : Attribute
   {
     /// <param name="formatParameterName">
-    /// Specifies which parameter of an annotated method should be treated as the format string
+    /// Specifies which parameter of an annotated method should be treated as the format string.
     /// </param>
     public StringFormatMethodAttribute([NotNull] string formatParameterName)
     {
@@ -143,7 +143,7 @@ namespace JetBrains.Annotations
 
   /// <summary>
   /// Indicates that the marked parameter is a message template where placeholders are to be replaced by the following arguments
-  /// in the order in which they appear
+  /// in the order in which they appear.
   /// </summary>
   /// <example><code>
   /// void LogInfo([StructuredMessageTemplate]string message, params object[] args) { /* do something */ }
@@ -325,7 +325,7 @@ namespace JetBrains.Annotations
   }
 
   /// <summary>
-  /// Describes dependency between method input and output.
+  /// Describes dependence between method input and output.
   /// </summary>
   /// <syntax>
   /// <p>Function Definition Table syntax:</p>
@@ -435,7 +435,7 @@ namespace JetBrains.Annotations
 
   /// <summary>
   /// When applied to a target attribute, specifies a requirement for any type marked
-  /// with the target attribute to implement or inherit specific type or types.
+  /// with the target attribute to implement or inherit the specific type or types.
   /// </summary>
   /// <example><code>
   /// [BaseTypeRequired(typeof(IComponent)] // Specify requirement
@@ -531,7 +531,7 @@ namespace JetBrains.Annotations
   }
 
   /// <summary>
-  /// Specifies the details of implicitly used symbol when it is marked
+  /// Specifies the details of an implicitly used symbol when it is marked
   /// with <see cref="MeansImplicitUseAttribute"/> or <see cref="UsedImplicitlyAttribute"/>.
   /// </summary>
   [Flags]
@@ -569,7 +569,7 @@ namespace JetBrains.Annotations
   }
 
   /// <summary>
-  /// This attribute is intended to mark publicly available API,
+  /// This attribute is intended to mark publicly available APIs,
   /// which should not be removed and so is treated as used.
   /// </summary>
   [MeansImplicitUse(ImplicitUseTargetFlags.WithMembers)]
@@ -589,18 +589,18 @@ namespace JetBrains.Annotations
 
   /// <summary>
   /// Tells the code analysis engine if the parameter is completely handled when the invoked method is on stack.
-  /// If the parameter is a delegate, indicates that delegate can only be invoked during method execution
+  /// If the parameter is a delegate, indicates that the delegate can only be invoked during method execution
   /// (the delegate can be invoked zero or multiple times, but not stored to some field and invoked later,
   /// when the containing method is no longer on the execution stack).
   /// If the parameter is an enumerable, indicates that it is enumerated while the method is executed.
-  /// If <see cref="RequireAwait"/> is true, the attribute will only takes effect if the method invocation is located under the 'await' expression.
+  /// If <see cref="RequireAwait"/> is true, the attribute will only take effect if the method invocation is located under the 'await' expression.
   /// </summary>
   [AttributeUsage(AttributeTargets.Parameter)]
   [Conditional("JETBRAINS_ANNOTATIONS")]
   public sealed class InstantHandleAttribute : Attribute
   {
     /// <summary>
-    /// Require the method invocation to be used under the 'await' expression for this attribute to take effect on code analysis engine.
+    /// Require the method invocation to be used under the 'await' expression for this attribute to take effect on the code analysis engine.
     /// Can be used for delegate/enumerable parameters of 'async' methods.
     /// </summary>
     public bool RequireAwait { get; set; }
@@ -648,15 +648,15 @@ namespace JetBrains.Annotations
 
   /// <summary>
   /// This annotation allows to enforce allocation-less usage patterns of delegates for performance-critical APIs.
-  /// When this annotation is applied to the parameter of delegate type, IDE checks the input argument of this parameter:
-  /// * When lambda expression or anonymous method is passed as an argument, IDE verifies that the passed closure
+  /// When this annotation is applied to the parameter of delegate type, the IDE checks the input argument of this parameter:
+  /// * When a lambda expression or anonymous method is passed as an argument, the IDE verifies that the passed closure
   ///   has no captures of the containing local variables and the compiler is able to cache the delegate instance
-  ///   to avoid heap allocations. Otherwise the warning is produced.
-  /// * IDE warns when method name or local function name is passed as an argument as this always results
+  ///   to avoid heap allocations. Otherwise a warning is produced.
+  /// * The IDE warns when the method name or local function name is passed as an argument as this always results
   ///   in heap allocation of the delegate instance.
   /// </summary>
   /// <remarks>
-  /// In C# 9.0 code IDE would also suggest to annotate the anonymous function with 'static' modifier
+  /// In C# 9.0+ code, the IDE will also suggest to annotate the anonymous function with the 'static' modifier
   /// to make use of the similar analysis provided by the language/compiler.
   /// </remarks>
   [AttributeUsage(AttributeTargets.Parameter)]
@@ -667,9 +667,9 @@ namespace JetBrains.Annotations
   }
 
   /// <summary>
-  /// Indicates the type member or parameter of some type, that should be used instead of all other ways
+  /// Indicates the type member or parameter of some type that should be used instead of all other ways
   /// to get the value of that type. This annotation is useful when you have some "context" value evaluated
-  /// and stored somewhere, meaning that all other ways to get this value must be consolidated with existing one.
+  /// and stored somewhere, meaning that all other ways to get this value must be consolidated with the existing one.
   /// </summary>
   /// <example><code>
   /// class Foo {
@@ -708,17 +708,17 @@ namespace JetBrains.Annotations
   /// <summary>
   /// An extension method marked with this attribute is processed by code completion
   /// as a 'Source Template'. When the extension method is completed over some expression, its source code
-  /// is automatically expanded like a template at call site.
+  /// is automatically expanded like a template at the call site.
   /// </summary>
   /// <remarks>
-  /// Template method body can contain valid source code and/or special comments starting with '$'.
+  /// Template method bodies can contain valid source code and/or special comments starting with '$'.
   /// Text inside these comments is added as source code when the template is applied. Template parameters
   /// can be used either as additional method parameters or as identifiers wrapped in two '$' signs.
   /// Use the <see cref="MacroAttribute"/> attribute to specify macros for parameters.
   /// </remarks>
   /// <example>
   /// In this example, the 'forEach' method is a source template available over all values
-  /// of enumerable types, producing ordinary C# 'foreach' statement and placing caret inside block:
+  /// of enumerable types, producing ordinary C# 'foreach' statement and placing the caret inside the block:
   /// <code>
   /// [SourceTemplate]
   /// public static void forEach&lt;T&gt;(this IEnumerable&lt;T&gt; xs) {
@@ -739,7 +739,7 @@ namespace JetBrains.Annotations
   /// You can apply the attribute on the whole method or on any of its additional parameters. The macro expression
   /// is defined in the <see cref="MacroAttribute.Expression"/> property. When applied on a method, the target
   /// template parameter is defined in the <see cref="MacroAttribute.Target"/> property. To apply the macro silently
-  /// for the parameter, set the <see cref="MacroAttribute.Editable"/> property value = -1.
+  /// for the parameter, set the <see cref="MacroAttribute.Editable"/> property value to -1.
   /// </remarks>
   /// <example>
   /// Applying the attribute on a source template method:
@@ -788,9 +788,9 @@ namespace JetBrains.Annotations
   }
 
   /// <summary>
-  /// Indicates how method, constructor invocation, or property access
-  /// over collection type affects the contents of the collection.
-  /// When applied to a return value of a method indicates if the returned collection
+  /// Indicates how a method, constructor invocation, or property access
+  /// over a collection type affects the contents of the collection.
+  /// When applied to a return value of a method, indicates if the returned collection
   /// is created exclusively for the caller (CollectionAccessType.UpdatedContent) or
   /// can be read/updated from outside (CollectionAccessType.Read | CollectionAccessType.UpdatedContent)
   /// Use <see cref="CollectionAccessType"/> to specify the access type.
@@ -847,7 +847,7 @@ namespace JetBrains.Annotations
   }
 
   /// <summary>
-  /// Indicates that the marked method is assertion method, i.e. it halts the control flow if
+  /// Indicates that the marked method is an assertion method, i.e. it halts the control flow if
   /// one of the conditions is satisfied. To set the condition, mark one of the parameters with
   /// <see cref="AssertionConditionAttribute"/> attribute.
   /// </summary>
@@ -857,7 +857,7 @@ namespace JetBrains.Annotations
 
   /// <summary>
   /// Indicates the condition parameter of the assertion method. The method itself should be
-  /// marked by <see cref="AssertionMethodAttribute"/> attribute. The mandatory argument of
+  /// marked by the <see cref="AssertionMethodAttribute"/> attribute. The mandatory argument of
   /// the attribute is the assertion type.
   /// </summary>
   [AttributeUsage(AttributeTargets.Parameter)]
@@ -873,7 +873,7 @@ namespace JetBrains.Annotations
   }
 
   /// <summary>
-  /// Specifies assertion type. If the assertion method argument satisfies the condition,
+  /// Specifies the assertion type. If the assertion method argument satisfies the condition,
   /// then the execution continues. Otherwise, execution is assumed to be halted.
   /// </summary>
   public enum AssertionConditionType
@@ -890,7 +890,7 @@ namespace JetBrains.Annotations
 
   /// <summary>
   /// Indicates that the marked method unconditionally terminates control flow execution.
-  /// For example, it could unconditionally throw exception.
+  /// For example, it could unconditionally throw an exception.
   /// </summary>
   [Obsolete("Use [ContractAnnotation('=> halt')] instead")]
   [AttributeUsage(AttributeTargets.Method)]
@@ -934,7 +934,7 @@ namespace JetBrains.Annotations
   public sealed class RegexPatternAttribute : Attribute { }
 
   /// <summary>
-  /// Language of injected code fragment inside marked by <see cref="LanguageInjectionAttribute"/> string literal.
+  /// Language of injected code fragment inside marked by the <see cref="LanguageInjectionAttribute"/> string literal.
   /// </summary>
   public enum InjectedLanguage
   {
@@ -947,7 +947,7 @@ namespace JetBrains.Annotations
 
   /// <summary>
   /// Indicates that the marked parameter, field, or property is accepting a string literal
-  /// containing code fragment in a specified language.
+  /// containing code fragments in a specified language.
   /// </summary>
   /// <example><code>
   /// void Foo([LanguageInjection(InjectedLanguage.CSS, Prefix = "body{", Suffix = "}")] string cssProps)
@@ -974,16 +974,16 @@ namespace JetBrains.Annotations
       InjectedLanguageName = injectedLanguage;
     }
 
-    /// <summary>Specifies a language of injected code fragment.</summary>
+    /// <summary>Specifies a language of the injected code fragment.</summary>
     public InjectedLanguage InjectedLanguage { get; }
 
-    /// <summary>Specifies a language name of injected code fragment.</summary>
+    /// <summary>Specifies a language name of the injected code fragment.</summary>
     [CanBeNull] public string InjectedLanguageName { get; }
 
-    /// <summary>Specifies a string that "precedes" injected string literal.</summary>
+    /// <summary>Specifies a string that "precedes" the injected string literal.</summary>
     [CanBeNull] public string Prefix { get; set; }
 
-    /// <summary>Specifies a string that "follows" injected string literal.</summary>
+    /// <summary>Specifies a string that "follows" the injected string literal.</summary>
     [CanBeNull] public string Suffix { get; set; }
   }
 
@@ -1013,7 +1013,7 @@ namespace JetBrains.Annotations
   /// <item>$this$ - expression of containing type</item>
   /// <item>$thisType$ - containing type</item>
   /// <item>$member$ - current member placeholder</item>
-  /// <item>$qualifier$ - this placeholder is available in the replace pattern and can be used to insert qualifier expression matched by the $member$ placeholder.
+  /// <item>$qualifier$ - this placeholder is available in the replace pattern and can be used to insert a qualifier expression matched by the $member$ placeholder.
   /// (Note that if $qualifier$ placeholder is used, then $member$ placeholder will match only qualified references)</item>
   /// <item>$expression$ - expression of any type</item>
   /// <item>$identifier$ - identifier placeholder</item>
@@ -1034,8 +1034,8 @@ namespace JetBrains.Annotations
   /// Note that you can also define your own placeholders of the supported types and specify arguments for each placeholder type.
   /// This can be done using the following format: $name{type, arguments}$. Where 'name' - is the name of your placeholder,
   /// 'type' - is the type of your placeholder (one of the following: Expression, Type, Identifier, Statement, Argument, Member),
-  /// 'arguments' - arguments list for your placeholder. Each placeholder type supports it's own arguments, check examples below for mode details.
-  /// Placeholder type may be omitted and determined from the placeholder name, if name has one of the following prefixes:
+  /// 'arguments' - arguments list for your placeholder. Each placeholder type supports its own arguments, check examples below for more details.
+  /// The placeholder type may be omitted and determined from the placeholder name, if the name has one of the following prefixes:
   /// <list type="bullet">
   /// <item>expr, expression - expression placeholder, e.g. $exprPlaceholder{}$, $expressionFoo{}$</item>
   /// <item>arg, argument - argument placeholder, e.g. $argPlaceholder{}$, $argumentFoo{}$</item>
@@ -1151,7 +1151,7 @@ namespace JetBrains.Annotations
 
     /// <summary>
     /// Structural search pattern to use in the code template.
-    /// Pattern includes textual part, which must contain only identifiers allowed in the target language,
+    /// The pattern includes a textual part, which must contain only identifiers allowed in the target language,
     /// and placeholders, which allow matching variable parts of the target code blocks.
     /// </summary>
     public string SearchTemplate { get; }
@@ -1159,8 +1159,8 @@ namespace JetBrains.Annotations
     /// <summary>
     /// Message to show when the search pattern was found.
     /// You can also prepend the message text with "Error:", "Warning:", "Suggestion:" or "Hint:" prefix to specify the pattern severity.
-    /// Code patterns with replace template produce suggestions by default.
-    /// However, if replace template is not provided, then warning severity will be used.
+    /// Code patterns with replace templates produce suggestions by default.
+    /// However, if a replace template is not provided, then warning severity will be used.
     /// </summary>
     public string Message { get; set; }
 
@@ -1170,7 +1170,7 @@ namespace JetBrains.Annotations
     public string ReplaceTemplate { get; set; }
 
     /// <summary>
-    /// Replace message to show in the light bulb.
+    /// The replace message to show in the light bulb.
     /// </summary>
     public string ReplaceMessage { get; set; }
 
@@ -1190,7 +1190,7 @@ namespace JetBrains.Annotations
     public bool ShortenReferences { get; set; }
 
     /// <summary>
-    /// String to use as a suppression key.
+    /// The string to use as a suppression key.
     /// By default the following suppression key is used 'CodeTemplate_SomeType_SomeMember',
     /// where 'SomeType' and 'SomeMember' are names of the associated containing type and member to which this attribute is applied.
     /// </summary>
@@ -1503,13 +1503,13 @@ namespace JetBrains.Annotations
 
   /// <summary>
   /// Indicates that the marked type is custom route parameter constraint,
-  /// which is registered in application's Startup with name <c>ConstraintName</c>
+  /// which is registered in the application's Startup with the name <c>ConstraintName</c>.
   /// </summary>
   /// <remarks>
   /// You can specify <c>ProposedType</c> if target constraint matches only route parameters of specific type,
   /// it will allow IDE to create method's parameter from usage in route template
   /// with specified type instead of default <c>System.String</c>
-  /// and check if constraint's proposed type conflicts with matched parameter's type
+  /// and check if constraint's proposed type conflicts with matched parameter's type.
   /// </remarks>
   [AttributeUsage(AttributeTargets.Class)]
   [Conditional("JETBRAINS_ANNOTATIONS")]
@@ -1528,8 +1528,8 @@ namespace JetBrains.Annotations
   /// Indicates that the marked parameter, field, or property is an URI string.
   /// </summary>
   /// <remarks>
-  /// This attribute enables code completion, navigation, rename and other features
-  /// in URI string literals assigned to annotated parameter, field or property.
+  /// This attribute enables code completion, navigation, renaming and other features
+  /// in URI string literals assigned to annotated parameters, fields, or properties.
   /// </remarks>
   [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property)]
   [Conditional("JETBRAINS_ANNOTATIONS")]
@@ -1546,11 +1546,11 @@ namespace JetBrains.Annotations
   }
 
   /// <summary>
-  /// Indicates that the marked method declares routing convention for ASP.NET
+  /// Indicates that the marked method declares routing convention for ASP.NET.
   /// </summary>
   /// <remarks>
-  /// IDE will analyze all usages of methods marked with this attribute,
-  /// and will add all routes to completion, navigation and other features over URI strings
+  /// The IDE will analyze all usages of methods marked with this attribute,
+  /// and will add all routes to completion, navigation, and other features over URI strings.
   /// </remarks>
   [AttributeUsage(AttributeTargets.Method)]
   [Conditional("JETBRAINS_ANNOTATIONS")]
@@ -1567,39 +1567,39 @@ namespace JetBrains.Annotations
   }
 
   /// <summary>
-  /// Indicates that the marked method parameter contains default route values of routing convention for ASP.NET
+  /// Indicates that the marked method parameter contains default route values of routing convention for ASP.NET.
   /// </summary>
   [AttributeUsage(AttributeTargets.Parameter)]
   [Conditional("JETBRAINS_ANNOTATIONS")]
   public sealed class AspDefaultRouteValuesAttribute : Attribute { }
 
   /// <summary>
-  /// Indicates that the marked method parameter contains constraints on route values of routing convention for ASP.NET
+  /// Indicates that the marked method parameter contains constraints on route values of routing convention for ASP.NET.
   /// </summary>
   [AttributeUsage(AttributeTargets.Parameter)]
   [Conditional("JETBRAINS_ANNOTATIONS")]
   public sealed class AspRouteValuesConstraintsAttribute : Attribute { }
 
   /// <summary>
-  /// Indicates that the marked parameter or property contains routing order provided by ASP.NET routing attribute
+  /// Indicates that the marked parameter or property contains routing order provided by ASP.NET routing attribute.
   /// </summary>
   [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
   [Conditional("JETBRAINS_ANNOTATIONS")]
   public sealed class AspRouteOrderAttribute : Attribute { }
 
   /// <summary>
-  /// Indicates that the marked parameter or property contains HTTP verbs provided by ASP.NET routing attribute
+  /// Indicates that the marked parameter or property contains HTTP verbs provided by ASP.NET routing attribute.
   /// </summary>
   [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
   [Conditional("JETBRAINS_ANNOTATIONS")]
   public sealed class AspRouteVerbsAttribute : Attribute { }
 
   /// <summary>
-  /// Indicates that the marked attribute is used for attribute routing in ASP.NET
+  /// Indicates that the marked attribute is used for attribute routing in ASP.NET.
   /// </summary>
   /// <remarks>
-  /// IDE will analyze all usages of attributes marked with this attribute,
-  /// and will add all routes to completion, navigation and other features over URI strings
+  /// The IDE will analyze all usages of attributes marked with this attribute,
+  /// and will add all routes to completion, navigation and other features over URI strings.
   /// </remarks>
   [AttributeUsage(AttributeTargets.Class)]
   [Conditional("JETBRAINS_ANNOTATIONS")]
@@ -1609,11 +1609,11 @@ namespace JetBrains.Annotations
   }
 
   /// <summary>
-  /// Indicates that the marked method declares ASP.NET Minimal API endpoint
+  /// Indicates that the marked method declares an ASP.NET Minimal API endpoint.
   /// </summary>
   /// <remarks>
-  /// IDE will analyze all usages of methods marked with this attribute,
-  /// and will add all routes to completion, navigation and other features over URI strings
+  /// The IDE will analyze all usages of methods marked with this attribute,
+  /// and will add all routes to completion, navigation and other features over URI strings.
   /// </remarks>
   [AttributeUsage(AttributeTargets.Method)]
   [Conditional("JETBRAINS_ANNOTATIONS")]
@@ -1623,14 +1623,14 @@ namespace JetBrains.Annotations
   }
 
   /// <summary>
-  /// Indicates that the marked method declares ASP.NET Minimal API endpoints group
+  /// Indicates that the marked method declares an ASP.NET Minimal API endpoints group.
   /// </summary>
   [AttributeUsage(AttributeTargets.Method)]
   [Conditional("JETBRAINS_ANNOTATIONS")]
   public sealed class AspMinimalApiGroupAttribute : Attribute { }
 
   /// <summary>
-  /// Indicates that the marked parameter contains ASP.NET Minimal API endpoint handler
+  /// Indicates that the marked parameter contains an ASP.NET Minimal API endpoint handler.
   /// </summary>
   [AttributeUsage(AttributeTargets.Parameter)]
   [Conditional("JETBRAINS_ANNOTATIONS")]
@@ -1757,8 +1757,8 @@ namespace JetBrains.Annotations
   #region XAML
 
   /// <summary>
-  /// XAML attribute. Indicates the type that has <c>ItemsSource</c> property and should be treated
-  /// as <c>ItemsControl</c>-derived type, to enable inner items <c>DataContext</c> type resolve.
+  /// XAML attribute. Indicates the type that has an <c>ItemsSource</c> property and should be treated
+  /// as an <c>ItemsControl</c>-derived type, to enable inner items <c>DataContext</c> type resolvement.
   /// </summary>
   [AttributeUsage(AttributeTargets.Class)]
   [Conditional("JETBRAINS_ANNOTATIONS")]
@@ -1766,11 +1766,11 @@ namespace JetBrains.Annotations
 
   /// <summary>
   /// XAML attribute. Indicates the property of some <c>BindingBase</c>-derived type, that
-  /// is used to bind some item of <c>ItemsControl</c>-derived type. This annotation will
+  /// is used to bind some item of an <c>ItemsControl</c>-derived type. This annotation will
   /// enable the <c>DataContext</c> type resolve for XAML bindings for such properties.
   /// </summary>
   /// <remarks>
-  /// Property should have the tree ancestor of the <c>ItemsControl</c> type or
+  /// The property should have the tree ancestor of the <c>ItemsControl</c> type, or
   /// marked with the <see cref="XamlItemsControlAttribute"/> attribute.
   /// </remarks>
   [AttributeUsage(AttributeTargets.Property)]
@@ -1778,8 +1778,8 @@ namespace JetBrains.Annotations
   public sealed class XamlItemBindingOfItemsControlAttribute : Attribute { }
 
   /// <summary>
-  /// XAML attribute. Indicates the property of some <c>Style</c>-derived type, that
-  /// is used to style items of <c>ItemsControl</c>-derived type. This annotation will
+  /// XAML attribute. Indicates the property of some <c>Style</c>-derived type that
+  /// is used to style items of an <c>ItemsControl</c>-derived type. This annotation will
   /// enable the <c>DataContext</c> type resolve for XAML bindings for such properties.
   /// </summary>
   /// <remarks>
@@ -1794,7 +1794,7 @@ namespace JetBrains.Annotations
   /// XAML attribute. Indicates that DependencyProperty has <c>OneWay</c> binding mode by default.
   /// </summary>
   /// <remarks>
-  /// This attribute must be applied to DependencyProperty's CLR accessor property if it is present, to DependencyProperty descriptor field otherwise.
+  /// This attribute must be applied to DependencyProperty's CLR accessor property if it is present, or to a DependencyProperty descriptor field otherwise.
   /// </remarks>
   [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
   [Conditional("JETBRAINS_ANNOTATIONS")]
@@ -1804,7 +1804,7 @@ namespace JetBrains.Annotations
   /// XAML attribute. Indicates that DependencyProperty has <c>TwoWay</c> binding mode by default.
   /// </summary>
   /// <remarks>
-  /// This attribute must be applied to DependencyProperty's CLR accessor property if it is present, to DependencyProperty descriptor field otherwise.
+  /// This attribute must be applied to DependencyProperty's CLR accessor property if it is present, or to a DependencyProperty descriptor field otherwise.
   /// </remarks>
   [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
   [Conditional("JETBRAINS_ANNOTATIONS")]


### PR DESCRIPTION
While using this library I noticed a number of typos in its XML documentation, so I tried correcting all that I could find. This commit is a non-breaking change.

Please proofread all corrections before merging, thank you and have a wonderful day!