### PR TITLE
Allow NoReorderAttribute to be used for partial classes to indicate w…

### DIFF
--- a/src/Annotations.cs
+++ b/src/Annotations.cs
@@ -1072,7 +1072,7 @@ namespace JetBrains.Annotations
   /// The attribute must be mentioned in your member reordering patterns.
   /// </remarks>
   [AttributeUsage(
-    AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Enum)]
+    AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Enum, AllowMultiple = true)]
   [Conditional("JETBRAINS_ANNOTATIONS")]
   public sealed class NoReorderAttribute : Attribute { }
 


### PR DESCRIPTION
Allow NoReorderAttribute to be used for partial classes to indicate which part (or parts) file layout should not be applied to.
See also: RSRP-494304 NoReorder attribute cannot be used with partial classes.