### PR TITLE
NP-1680 Added copyright information to nuspec

### DIFF
--- a/license.md
+++ b/license.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 JetBrains http://www.jetbrains.com
+Copyright (c) 2016-2024 JetBrains s.r.o.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/JetBrains.Annotations.nuspec
+++ b/src/JetBrains.Annotations.nuspec
@@ -10,6 +10,7 @@
     <repository type="git" url="https://github.com/JetBrains/JetBrains.Annotations.git" />
     <icon>icon.png</icon>
     <license type="expression">MIT</license>
+    <copyright>Copyright (c) 2016-2024 JetBrains s.r.o.</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Annotations to increase accuracy of JetBrains Rider and ReSharper code inspections</summary>
     <description>
@@ -23,6 +24,7 @@ All usages of JetBrains.Annotations attributes are erased from metadata by defau
 &#8226; Added IgnoreSpellingAndGrammarErrorsAttribute to allow ignore grammar and spelling errors in literals passed to marked parameters.
 &#8226; Added AspMinimalApiImplicitEndpointDeclarationAttribute to make IDE aware of Minimal API endpoints from third-party libraries.
 &#8226; NoReorderAttribute can now be applied to multiple parts of the same type.
+&#8226; Added copyright information to nuspec.
     </releaseNotes>
     <tags>jetbrains resharper rider annotations canbenull notnull</tags>
     <dependencies>


### PR DESCRIPTION
The value from the license.md file in the root of the repository was used as the copyright.