### PR TITLE
NuGet: fix the repository URL

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <Authors>JetBrains</Authors>
     <Copyright>Copyright (c) 2016-2025 JetBrains s.r.o.</Copyright>
     <PackageProjectUrl>https://www.jetbrains.com/help/resharper/Code_Analysis__Code_Annotations.html</PackageProjectUrl>
-    <PackageGitUrl>https://github.com/JetBrains/JetBrains.Annotations.git2</PackageGitUrl>
+    <PackageGitUrl>https://github.com/JetBrains/JetBrains.Annotations.git</PackageGitUrl>
 
     <PackageSummary>Annotations to increase accuracy of JetBrains Rider and ReSharper code inspections</PackageSummary>
     <Description>


### PR DESCRIPTION
I might be wrong, but the current URL looks invalid.