### PR TITLE
Add DEBUG condition to DebuggerGlobalWatchAttribute

### DIFF
--- a/src/Annotations.cs
+++ b/src/Annotations.cs
@@ -1505,6 +1505,7 @@ namespace JetBrains.Annotations
   /// }
   /// </code></example>
   [AttributeUsage(AttributeTargets.Property)]
+  [Conditional("DEBUG")]
   [Conditional("JETBRAINS_ANNOTATIONS")]
   public sealed class DebuggerGlobalWatchAttribute : Attribute
   {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,7 @@
         MAJOR and MINOR version numbers should match latest ReSharper version (to avoid confusion),
         PATCH version may vary during development and EAPs -->
     <VersionPrefix>2026.2.0</VersionPrefix>
-    <VersionSuffix>eap1</VersionSuffix>
+    <VersionSuffix>eap2</VersionSuffix>
 
     <PackageReleaseNotes>
 &#8226; Added DebuggerGlobalWatchAttribute.


### PR DESCRIPTION
Adds the second condition, so the attribute is not erased in debug builds.